### PR TITLE
Adds Event command

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -17,24 +17,90 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/urfave/cli"
 	"github.com/sbuckfelder/github-monitoring-tool/proxy"
 )
 
+const (
+	ORG_NAME string = "org"
+	REPO_NAME string = "repo"
+	SINCE_NAME string = "since"
+	DATE_NAME string = "date"
+	HOURS_NAME string = "hours"
+)
+
 var eventsCommand = cli.Command{
 	Name:  "events",
-	Usage: "list events for a repo",
+	Usage: "List events for a github org/repo provide one of [hours,date,since]",
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:  "repo",
+			Name:  REPO_NAME,
 			Usage: "github repo to list events for",
+			Required: true,
+		},
+		cli.StringFlag{
+			Name:  ORG_NAME,
+			Usage: "github org repo belongs to",
+			Required: true,
+		},
+		cli.StringFlag{
+			Name:  SINCE_NAME,
+			Usage: "timestamp in RFC3339 format e.g. 2006-01-02T15:04:05Z",
+			Required: false,
+		},
+		cli.IntFlag{
+			Name:  HOURS_NAME,
+			Usage: "number of hours to look back",
+			Required: false,
+		},
+		cli.StringFlag{
+			Name:  DATE_NAME,
+			Usage: "date for events format YYYY-MM-DD",
+			Required: false,
 		},
 	},
 	Action: func(ctx *cli.Context) error {
-		_, err := proxy.NewProxy()
+		orgInput := ctx.String(ORG_NAME)
+		repoInput:= ctx.String(REPO_NAME)
+		sinceInput := ctx.String(SINCE_NAME)
+		dateInput := ctx.String(DATE_NAME)
+		hoursInput := ctx.Int(HOURS_NAME)
+
+		if sinceInput == "" && dateInput == "" && hoursInput == 0 {
+			return errors.New("No time flag [since,date,hours] is set")
+		} 
+		
+		if sinceInput != "" && dateInput != "" { 
+			return errors.New("Cannot have both since and date set")
+		} 
+		
+		if sinceInput != "" && hoursInput != 0 {
+			return errors.New("Cannot have both since and hours set")
+		} 
+		
+		if dateInput != "" && hoursInput != 0 {
+			return errors.New("Cannot have both date and hours set")
+		} 
+
+		ghProxy, err := proxy.NewProxy()
 		if err != nil {
 			panic("Failed to create GitHub client")
 		}
+
+		if dateInput != "" {
+			ghProxy.GetEventsForDate(orgInput, repoInput, dateInput)
+		}
+		
+		if sinceInput != "" {
+			ghProxy.GetEventsSinceRFC3339(orgInput, repoInput, sinceInput)
+		}
+		
+		if hoursInput != 0 {
+			ghProxy.GetEventsForHours(orgInput, repoInput, hoursInput)
+		}
+
 		return nil
 	},
 }

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -19,16 +19,17 @@ package main
 import (
 	"errors"
 
-	"github.com/urfave/cli"
 	"github.com/sbuckfelder/github-monitoring-tool/proxy"
+	"github.com/urfave/cli"
 )
 
 const (
-	ORG_NAME string = "org"
-	REPO_NAME string = "repo"
-	SINCE_NAME string = "since"
-	DATE_NAME string = "date"
-	HOURS_NAME string = "hours"
+	ORG_NAME     string = "org"
+	REPOALL_NAME string = "repoall"
+	REPO_NAME    string = "repo"
+	SINCE_NAME   string = "since"
+	DATE_NAME    string = "date"
+	HOURS_NAME   string = "hours"
 )
 
 var eventsCommand = cli.Command{
@@ -36,69 +37,91 @@ var eventsCommand = cli.Command{
 	Usage: "List events for a github org/repo provide one of [hours,date,since]",
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:  REPO_NAME,
-			Usage: "github repo to list events for",
+			Name:     ORG_NAME,
+			Usage:    "github org repo belongs to",
 			Required: true,
 		},
-		cli.StringFlag{
-			Name:  ORG_NAME,
-			Usage: "github org repo belongs to",
-			Required: true,
+		cli.BoolFlag{
+			Name:     REPOALL_NAME,
+			Usage:    "get events for all repos in an organization, cannot be used with repo flag",
+			Required: false,
 		},
 		cli.StringFlag{
-			Name:  SINCE_NAME,
-			Usage: "timestamp in RFC3339 format e.g. 2006-01-02T15:04:05Z",
+			Name:     REPO_NAME,
+			Usage:    "github repo to list events for, cannot be used with repoall flag",
+			Required: false,
+		},
+		cli.StringFlag{
+			Name:     SINCE_NAME,
+			Usage:    "timestamp in RFC3339 format e.g. 2006-01-02T15:04:05Z",
 			Required: false,
 		},
 		cli.IntFlag{
-			Name:  HOURS_NAME,
-			Usage: "number of hours to look back",
+			Name:     HOURS_NAME,
+			Usage:    "number of hours to look back",
 			Required: false,
 		},
 		cli.StringFlag{
-			Name:  DATE_NAME,
-			Usage: "date for events format YYYY-MM-DD",
+			Name:     DATE_NAME,
+			Usage:    "date for events format YYYY-MM-DD",
 			Required: false,
 		},
 	},
 	Action: func(ctx *cli.Context) error {
 		orgInput := ctx.String(ORG_NAME)
-		repoInput:= ctx.String(REPO_NAME)
+		repoAllInput := ctx.Bool(REPOALL_NAME)
+		repoInput := ctx.String(REPO_NAME)
 		sinceInput := ctx.String(SINCE_NAME)
 		dateInput := ctx.String(DATE_NAME)
 		hoursInput := ctx.Int(HOURS_NAME)
 
+		if repoAllInput && repoInput != "" {
+			return errors.New("Both 'repo' and 'repoall' flag cannot be set")
+		}
+
+		if !repoAllInput && repoInput == "" {
+			return errors.New("Either 'repo' or 'repoall' needs to be set")
+		}
+
 		if sinceInput == "" && dateInput == "" && hoursInput == 0 {
 			return errors.New("No time flag [since,date,hours] is set")
-		} 
-		
-		if sinceInput != "" && dateInput != "" { 
+		}
+
+		if sinceInput != "" && dateInput != "" {
 			return errors.New("Cannot have both since and date set")
-		} 
-		
+		}
+
 		if sinceInput != "" && hoursInput != 0 {
 			return errors.New("Cannot have both since and hours set")
-		} 
-		
+		}
+
 		if dateInput != "" && hoursInput != 0 {
 			return errors.New("Cannot have both date and hours set")
-		} 
+		}
 
 		ghProxy, err := proxy.NewProxy()
 		if err != nil {
 			panic("Failed to create GitHub client")
 		}
 
+		var repos = []string{}
+
+		if repoAllInput {
+			repos = ghProxy.GetReposForOrg(orgInput)
+		} else {
+			repos = append(repos, repoInput)
+		}
+
 		if dateInput != "" {
-			ghProxy.GetEventsForDate(orgInput, repoInput, dateInput)
+			ghProxy.GetEventsForDate(orgInput, repos, dateInput)
 		}
-		
+
 		if sinceInput != "" {
-			ghProxy.GetEventsSinceRFC3339(orgInput, repoInput, sinceInput)
+			ghProxy.GetEventsSinceRFC3339(orgInput, repos, sinceInput)
 		}
-		
+
 		if hoursInput != 0 {
-			ghProxy.GetEventsForHours(orgInput, repoInput, hoursInput)
+			ghProxy.GetEventsForHours(orgInput, repos, hoursInput)
 		}
 
 		return nil

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -18,8 +18,8 @@ package proxy
 
 import (
 	"context"
-	"io/ioutil"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -37,11 +37,11 @@ type GithubProxy struct {
 
 func NewProxy() (GithubProxy, error) {
 	ctx := context.Background()
-	token, err := getToken()	
+	token, err := getToken()
 	if err != nil {
 		panicMsg := fmt.Sprintf("Failed to get token from %s: %v", getTokenFileName(), err)
 		panic(panicMsg)
-	}	
+	}
 	tokenSource := oauth2.StaticTokenSource(
 		&oauth2.Token{
 			AccessToken: token},
@@ -53,7 +53,7 @@ func NewProxy() (GithubProxy, error) {
 }
 
 func getTokenFileName() string {
-	homeDir, _  := os.UserHomeDir()
+	homeDir, _ := os.UserHomeDir()
 	return homeDir + "/" + tokenFile
 }
 

--- a/proxy/events.go
+++ b/proxy/events.go
@@ -20,35 +20,41 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v48/github"
 )
 
-var EVENTS_PER_PAGE = 100
+var EVENTS_PER_PAGE int = 100
+var REPORT_SEPERATOR string = strings.Repeat("*", 20)
 
-func (p *GithubProxy) GetEventsForHours(org, repo string, hours int) {
+func (p *GithubProxy) GetEventsForHours(org string, repos []string, hours int) {
 	currentTime := time.Now()
 	adjTime := currentTime.Add(time.Hour * time.Duration(-1*hours))
 	ctx := context.Background()
-	events, _ := p.getEventsSince(ctx, org, repo, adjTime)
-	fmt.Printf("https://github.com/%s/%s Events Since %s\n", org, repo, adjTime.Format(time.RFC3339))
-	GenerateEventReport(events)
+	for _, repo := range repos {
+		events, _ := p.getEventsSince(ctx, org, repo, adjTime)
+		fmt.Printf("https://github.com/%s/%s Events Since %s\n", org, repo, adjTime.Format(time.RFC3339))
+		GenerateEventReport(events)
+	}
 }
 
-func (p *GithubProxy) GetEventsSinceRFC3339(org, repo string, sinceString string) {
+func (p *GithubProxy) GetEventsSinceRFC3339(org string, repos []string, sinceString string) {
 	since, err := time.Parse(time.RFC3339, sinceString)
 	if err != nil {
 		panicMsg := fmt.Sprintf("Since value:'%s' not in RFC3339 e.g. 2006-01-02T15:04:05Z", sinceString)
 		panic(panicMsg)
 	}
 	ctx := context.Background()
-	events, _ := p.getEventsSince(ctx, org, repo, since)
-	fmt.Printf("https://github.com/%s/%s Events Since %s\n", org, repo, sinceString)
-	GenerateEventReport(events)
+	for _, repo := range repos {
+		events, _ := p.getEventsSince(ctx, org, repo, since)
+		fmt.Printf("https://github.com/%s/%s Events Since %s\n", org, repo, sinceString)
+		GenerateEventReport(events)
+	}
 }
 
-func (p *GithubProxy) GetEventsForDate(org, repo string, dateString string) {
+func (p *GithubProxy) GetEventsForDate(org string, repos []string, dateString string) {
 	const dateLayout = "2006-01-02"
 	targetDate, err := time.Parse(dateLayout, dateString)
 	if err != nil {
@@ -56,10 +62,12 @@ func (p *GithubProxy) GetEventsForDate(org, repo string, dateString string) {
 		panic(panicMsg)
 	}
 	ctx := context.Background()
-	events, _ := p.getEventsSince(ctx, org, repo, targetDate)
-	events = filterEvents(events, eventFilterDate(targetDate))
-	fmt.Printf("https://github.com/%s/%s Events for %s\n", org, repo, dateString)
-	GenerateEventReport(events)
+	for _, repo := range repos {
+		events, _ := p.getEventsSince(ctx, org, repo, targetDate)
+		events = filterEvents(events, eventFilterDate(targetDate))
+		fmt.Printf("https://github.com/%s/%s Events for %s\n", org, repo, dateString)
+		GenerateEventReport(events)
+	}
 }
 
 func (p *GithubProxy) getEventsSince(
@@ -107,10 +115,10 @@ func eventFilterSince(since time.Time) func(*github.Event) bool {
 
 func eventFilterDate(date time.Time) func(*github.Event) bool {
 	return func(event *github.Event) bool {
-		return event.CreatedAt.Year() == date.Year() && 
-			event.CreatedAt.Month() == date.Month() && 
+		return event.CreatedAt.Year() == date.Year() &&
+			event.CreatedAt.Month() == date.Month() &&
 			event.CreatedAt.Day() == date.Day()
-			
+
 	}
 }
 
@@ -128,13 +136,13 @@ func eventFilterType() func(*github.Event) bool {
 func printPullRequestReport(events []*github.Event) {
 	var newPRs = []*github.Event{}
 	var mergedPRs = []*github.Event{}
-	for _, event := range(events) {
+	for _, event := range events {
 		payload, _ := event.ParsePayload()
 		prEvent := payload.(*github.PullRequestEvent)
 		if *prEvent.Action == "opened" {
 			newPRs = append(newPRs, event)
 		}
-		if *prEvent.Action == "closed" && *prEvent.PullRequest.Merged { 
+		if *prEvent.Action == "closed" && *prEvent.PullRequest.Merged {
 			mergedPRs = append(mergedPRs, event)
 		}
 	}
@@ -142,12 +150,12 @@ func printPullRequestReport(events []*github.Event) {
 		fmt.Printf("===========\n")
 		fmt.Printf("PR'S MERGED\n")
 		fmt.Printf("===========\n")
-		var mergedPRText = sort.StringSlice{} 
-		for _, prEvent := range(mergedPRs) {
+		var mergedPRText = sort.StringSlice{}
+		for _, prEvent := range mergedPRs {
 			mergedPRText = append(mergedPRText, printPullRequestEvent(prEvent))
-		} 
+		}
 		mergedPRText.Sort()
-		for _, txt := range(mergedPRText) {
+		for _, txt := range mergedPRText {
 			fmt.Print(txt)
 		}
 	}
@@ -155,12 +163,12 @@ func printPullRequestReport(events []*github.Event) {
 		fmt.Printf("=================\n")
 		fmt.Printf("NEW PULL REQUESTS\n")
 		fmt.Printf("=================\n")
-		var newPRText = sort.StringSlice{} 
-		for _, prEvent := range(newPRs) {
+		var newPRText = sort.StringSlice{}
+		for _, prEvent := range newPRs {
 			newPRText = append(newPRText, printPullRequestEvent(prEvent))
-		} 
+		}
 		newPRText.Sort()
-		for _, txt := range(newPRText) {
+		for _, txt := range newPRText {
 			fmt.Print(txt)
 		}
 	}
@@ -169,8 +177,8 @@ func printPullRequestReport(events []*github.Event) {
 func printPullRequestEvent(event *github.Event) string {
 	payload, _ := event.ParsePayload()
 	prEvent := payload.(*github.PullRequestEvent)
-	return fmt.Sprintf("PR#%d %s: %s %s\n", 
-		*prEvent.Number, 
+	return fmt.Sprintf("PR#%d %s: %s %s\n",
+		*prEvent.Number,
 		*prEvent.PullRequest.User.Login,
 		*prEvent.PullRequest.Title,
 		*prEvent.PullRequest.HTMLURL)
@@ -193,34 +201,34 @@ func getPullRequestURLFromReview(event *github.Event) (string, string) {
 func printPullRequestReviewReport(events []*github.Event) {
 	reviewMap := make(map[string]int)
 	titleMap := make(map[string]string)
-	for _, event := range(events) {
+	for _, event := range events {
 		url, title := getPullRequestURLFromReview(event)
 		reviewMap[url] = reviewMap[url] + 1
-		titleMap[url] = title 
+		titleMap[url] = title
 	}
 	fmt.Printf("==========================\n")
 	fmt.Printf("PR REVIEW/COMMENT ACTIVITY\n")
 	fmt.Printf("==========================\n")
-	var revText = sort.StringSlice{} 
-	for url, val := range(reviewMap) {
+	var revText = sort.StringSlice{}
+	for url, val := range reviewMap {
 		revText = append(revText, fmt.Sprintf("Actions:%d %s %s\n", val, titleMap[url], url))
 	}
 	revText.Sort()
-	for _, txt := range(revText) {
-			fmt.Print(txt)
+	for _, txt := range revText {
+		fmt.Print(txt)
 	}
 }
 
 func printIssueEventReport(events []*github.Event) {
 	var newIssues = []*github.Event{}
 	var closedIssues = []*github.Event{}
-	for _, event := range(events) {
+	for _, event := range events {
 		payload, _ := event.ParsePayload()
 		issuesEvent := payload.(*github.IssuesEvent)
 		if *issuesEvent.Action == "opened" {
 			newIssues = append(newIssues, event)
 		}
-		if *issuesEvent.Action == "closed" { 
+		if *issuesEvent.Action == "closed" {
 			closedIssues = append(closedIssues, event)
 		}
 	}
@@ -228,12 +236,12 @@ func printIssueEventReport(events []*github.Event) {
 		fmt.Printf("==========\n")
 		fmt.Printf("NEW ISSUES\n")
 		fmt.Printf("==========\n")
-		var newIssueText = sort.StringSlice{} 
-		for _, issueEvent := range(newIssues) {
+		var newIssueText = sort.StringSlice{}
+		for _, issueEvent := range newIssues {
 			newIssueText = append(newIssueText, printIssueEvent(issueEvent))
-		} 
+		}
 		newIssueText.Sort()
-		for _, txt := range(newIssueText) {
+		for _, txt := range newIssueText {
 			fmt.Print(txt)
 		}
 	}
@@ -241,12 +249,12 @@ func printIssueEventReport(events []*github.Event) {
 		fmt.Printf("=============\n")
 		fmt.Printf("CLOSED ISSUES\n")
 		fmt.Printf("=============\n")
-		var closedIssueText = sort.StringSlice{} 
-		for _, issueEvent := range(closedIssues) {
+		var closedIssueText = sort.StringSlice{}
+		for _, issueEvent := range closedIssues {
 			closedIssueText = append(closedIssueText, printIssueEvent(issueEvent))
-		} 
+		}
 		closedIssueText.Sort()
-		for _, txt := range(closedIssueText) {
+		for _, txt := range closedIssueText {
 			fmt.Print(txt)
 		}
 	}
@@ -255,8 +263,8 @@ func printIssueEventReport(events []*github.Event) {
 func printIssueEvent(event *github.Event) string {
 	payload, _ := event.ParsePayload()
 	issuesEvent := payload.(*github.IssuesEvent)
-	return fmt.Sprintf("ISSUE#%d %s: %s %s\n", 
-		*issuesEvent.Issue.Number, 
+	return fmt.Sprintf("ISSUE#%d %s: %s %s\n",
+		*issuesEvent.Issue.Number,
 		*issuesEvent.Issue.User.Login,
 		*issuesEvent.Issue.Title,
 		*issuesEvent.Issue.HTMLURL)
@@ -265,7 +273,7 @@ func printIssueEvent(event *github.Event) string {
 func printIssueCommentEventReport(events []*github.Event) {
 	commentMap := make(map[string]int)
 	titleMap := make(map[string]string)
-	for _, event := range(events) {
+	for _, event := range events {
 		payload, _ := event.ParsePayload()
 		commentEvent := payload.(*github.IssueCommentEvent)
 		url := *commentEvent.Issue.HTMLURL
@@ -275,52 +283,53 @@ func printIssueCommentEventReport(events []*github.Event) {
 	fmt.Printf("======================\n")
 	fmt.Printf("ISSUE COMMENT ACTIVITY\n")
 	fmt.Printf("======================\n")
-	var commentText = sort.StringSlice{} 
-	for url, val := range(commentMap) {
+	var commentText = sort.StringSlice{}
+	for url, val := range commentMap {
 		commentText = append(commentText, fmt.Sprintf("Comments:%d %s %s\n", val, titleMap[url], url))
 	}
 	commentText.Sort()
-	for _, txt := range(commentText) {
-			fmt.Print(txt)
+	for _, txt := range commentText {
+		fmt.Print(txt)
 	}
 }
 
 func GenerateEventReport(events []*github.Event) {
+	defer fmt.Printf("%s\n", REPORT_SEPERATOR)
 	eventMap := make(map[string][]*github.Event)
-	for _, event := range(events) {
+	for _, event := range events {
 		eventList, ok := eventMap[*event.Type]
 		if !ok {
 			eventList = []*github.Event{}
-		} 
+		}
 		eventList = append(eventList, event)
 		eventMap[*event.Type] = eventList
 	}
- 	if len(eventMap) == 0 {
-		fmt.Printf("No Events")
+	if len(eventMap) == 0 {
+		fmt.Printf("No Events\n")
 		return
-	}	
- 	prEvents, _ := eventMap["PullRequestEvent"]	
+	}
+	prEvents, _ := eventMap["PullRequestEvent"]
 	if len(prEvents) != 0 {
 		printPullRequestReport(prEvents)
 	}
- 	revEvents, _ := eventMap["PullRequestReviewEvent"]	
- 	revCommentEvents, _ := eventMap["PullRequestReviewCommentEvent"]	
+	revEvents, _ := eventMap["PullRequestReviewEvent"]
+	revCommentEvents, _ := eventMap["PullRequestReviewCommentEvent"]
 	revEvents = append(revEvents, revCommentEvents...)
 	if len(revEvents) != 0 {
 		printPullRequestReviewReport(revEvents)
 	}
- 	issueEvents, _ := eventMap["IssuesEvent"]	
+	issueEvents, _ := eventMap["IssuesEvent"]
 	if len(issueEvents) != 0 {
 		printIssueEventReport(issueEvents)
 	}
- 	issueCommentEvents, _ := eventMap["IssueCommentEvent"]	
+	issueCommentEvents, _ := eventMap["IssueCommentEvent"]
 	if len(issueCommentEvents) != 0 {
 		printIssueCommentEventReport(issueCommentEvents)
 	}
 	fmt.Printf("============\n")
 	fmt.Printf("EVENT REPORT\n")
 	fmt.Printf("============\n")
-  	for key, val := range(eventMap) {
+	for key, val := range eventMap {
 		fmt.Printf("%d %s\n", len(val), key)
-	}	
+	}
 }

--- a/proxy/events.go
+++ b/proxy/events.go
@@ -1,0 +1,326 @@
+/*
+   Copyright awslabs Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/go-github/v48/github"
+)
+
+var EVENTS_PER_PAGE = 100
+
+func (p *GithubProxy) GetEventsForHours(org, repo string, hours int) {
+	currentTime := time.Now()
+	adjTime := currentTime.Add(time.Hour * time.Duration(-1*hours))
+	ctx := context.Background()
+	events, _ := p.getEventsSince(ctx, org, repo, adjTime)
+	fmt.Printf("https://github.com/%s/%s Events Since %s\n", org, repo, adjTime.Format(time.RFC3339))
+	GenerateEventReport(events)
+}
+
+func (p *GithubProxy) GetEventsSinceRFC3339(org, repo string, sinceString string) {
+	since, err := time.Parse(time.RFC3339, sinceString)
+	if err != nil {
+		panicMsg := fmt.Sprintf("Since value:'%s' not in RFC3339 e.g. 2006-01-02T15:04:05Z", sinceString)
+		panic(panicMsg)
+	}
+	ctx := context.Background()
+	events, _ := p.getEventsSince(ctx, org, repo, since)
+	fmt.Printf("https://github.com/%s/%s Events Since %s\n", org, repo, sinceString)
+	GenerateEventReport(events)
+}
+
+func (p *GithubProxy) GetEventsForDate(org, repo string, dateString string) {
+	const dateLayout = "2006-01-02"
+	targetDate, err := time.Parse(dateLayout, dateString)
+	if err != nil {
+		panicMsg := fmt.Sprintf("Since value:'%s' not in YYYY-MM-DD e.g. 2006-01-02", dateString)
+		panic(panicMsg)
+	}
+	ctx := context.Background()
+	events, _ := p.getEventsSince(ctx, org, repo, targetDate)
+	events = filterEvents(events, eventFilterDate(targetDate))
+	fmt.Printf("https://github.com/%s/%s Events for %s\n", org, repo, dateString)
+	GenerateEventReport(events)
+}
+
+func (p *GithubProxy) getEventsSince(
+	ctx context.Context,
+	org, repo string,
+	since time.Time) ([]*github.Event, error) {
+	pageNumber := 1
+	found := false
+	var events []*github.Event
+	for found == false {
+		listOpts := &github.ListOptions{
+			PerPage: EVENTS_PER_PAGE,
+			Page:    pageNumber}
+
+		newEvents, _, err := p.client.Activity.ListRepositoryEvents(ctx, org, repo, listOpts)
+		if err != nil {
+			return nil, err
+		}
+		lastEvent := newEvents[len(newEvents)-1]
+		if lastEvent.CreatedAt.Before(since) {
+			found = true
+		}
+		events = append(events, newEvents...)
+		pageNumber++
+	}
+	events = filterEvents(events, eventFilterSince(since))
+	return events, nil
+}
+
+func filterEvents(events []*github.Event, filter func(*github.Event) bool) []*github.Event {
+	var filteredEvents []*github.Event
+	for _, event := range events {
+		if filter(event) {
+			filteredEvents = append(filteredEvents, event)
+		}
+	}
+	return filteredEvents
+}
+
+func eventFilterSince(since time.Time) func(*github.Event) bool {
+	return func(event *github.Event) bool {
+		return event.CreatedAt.After(since)
+	}
+}
+
+func eventFilterDate(date time.Time) func(*github.Event) bool {
+	return func(event *github.Event) bool {
+		return event.CreatedAt.Year() == date.Year() && 
+			event.CreatedAt.Month() == date.Month() && 
+			event.CreatedAt.Day() == date.Day()
+			
+	}
+}
+
+func eventFilterType() func(*github.Event) bool {
+	return func(event *github.Event) bool {
+		switch *event.Type {
+		case "IssuesEvent", "IssuesCommentEvent", "PullRequestEvent", "PullRequestReviewEvent", "PullRequestReviewCommentEvent":
+			return true
+		default:
+			return false
+		}
+	}
+}
+
+func printPullRequestReport(events []*github.Event) {
+	var newPRs = []*github.Event{}
+	var mergedPRs = []*github.Event{}
+	for _, event := range(events) {
+		payload, _ := event.ParsePayload()
+		prEvent := payload.(*github.PullRequestEvent)
+		if *prEvent.Action == "opened" {
+			newPRs = append(newPRs, event)
+		}
+		if *prEvent.Action == "closed" && *prEvent.PullRequest.Merged { 
+			mergedPRs = append(mergedPRs, event)
+		}
+	}
+	if len(mergedPRs) != 0 {
+		fmt.Printf("===========\n")
+		fmt.Printf("PR'S MERGED\n")
+		fmt.Printf("===========\n")
+		var mergedPRText = sort.StringSlice{} 
+		for _, prEvent := range(mergedPRs) {
+			mergedPRText = append(mergedPRText, printPullRequestEvent(prEvent))
+		} 
+		mergedPRText.Sort()
+		for _, txt := range(mergedPRText) {
+			fmt.Print(txt)
+		}
+	}
+	if len(newPRs) != 0 {
+		fmt.Printf("=================\n")
+		fmt.Printf("NEW PULL REQUESTS\n")
+		fmt.Printf("=================\n")
+		var newPRText = sort.StringSlice{} 
+		for _, prEvent := range(newPRs) {
+			newPRText = append(newPRText, printPullRequestEvent(prEvent))
+		} 
+		newPRText.Sort()
+		for _, txt := range(newPRText) {
+			fmt.Print(txt)
+		}
+	}
+}
+
+func printPullRequestEvent(event *github.Event) string {
+	payload, _ := event.ParsePayload()
+	prEvent := payload.(*github.PullRequestEvent)
+	return fmt.Sprintf("PR#%d %s: %s %s\n", 
+		*prEvent.Number, 
+		*prEvent.PullRequest.User.Login,
+		*prEvent.PullRequest.Title,
+		*prEvent.PullRequest.HTMLURL)
+}
+
+func getPullRequestURLFromReview(event *github.Event) (string, string) {
+	if *event.Type == "PullRequestReviewEvent" {
+		payload, _ := event.ParsePayload()
+		rev := payload.(*github.PullRequestReviewEvent)
+		return *rev.PullRequest.HTMLURL, *rev.PullRequest.Title
+	}
+	if *event.Type == "PullRequestReviewCommentEvent" {
+		payload, _ := event.ParsePayload()
+		rev := payload.(*github.PullRequestReviewCommentEvent)
+		return *rev.PullRequest.HTMLURL, *rev.PullRequest.Title
+	}
+	return "", ""
+}
+
+func printPullRequestReviewReport(events []*github.Event) {
+	reviewMap := make(map[string]int)
+	titleMap := make(map[string]string)
+	for _, event := range(events) {
+		url, title := getPullRequestURLFromReview(event)
+		reviewMap[url] = reviewMap[url] + 1
+		titleMap[url] = title 
+	}
+	fmt.Printf("==========================\n")
+	fmt.Printf("PR REVIEW/COMMENT ACTIVITY\n")
+	fmt.Printf("==========================\n")
+	var revText = sort.StringSlice{} 
+	for url, val := range(reviewMap) {
+		revText = append(revText, fmt.Sprintf("Actions:%d %s %s\n", val, titleMap[url], url))
+	}
+	revText.Sort()
+	for _, txt := range(revText) {
+			fmt.Print(txt)
+	}
+}
+
+func printIssueEventReport(events []*github.Event) {
+	var newIssues = []*github.Event{}
+	var closedIssues = []*github.Event{}
+	for _, event := range(events) {
+		payload, _ := event.ParsePayload()
+		issuesEvent := payload.(*github.IssuesEvent)
+		if *issuesEvent.Action == "opened" {
+			newIssues = append(newIssues, event)
+		}
+		if *issuesEvent.Action == "closed" { 
+			closedIssues = append(closedIssues, event)
+		}
+	}
+	if len(newIssues) != 0 {
+		fmt.Printf("==========\n")
+		fmt.Printf("NEW ISSUES\n")
+		fmt.Printf("==========\n")
+		var newIssueText = sort.StringSlice{} 
+		for _, issueEvent := range(newIssues) {
+			newIssueText = append(newIssueText, printIssueEvent(issueEvent))
+		} 
+		newIssueText.Sort()
+		for _, txt := range(newIssueText) {
+			fmt.Print(txt)
+		}
+	}
+	if len(closedIssues) != 0 {
+		fmt.Printf("=============\n")
+		fmt.Printf("CLOSED ISSUES\n")
+		fmt.Printf("=============\n")
+		var closedIssueText = sort.StringSlice{} 
+		for _, issueEvent := range(closedIssues) {
+			closedIssueText = append(closedIssueText, printIssueEvent(issueEvent))
+		} 
+		closedIssueText.Sort()
+		for _, txt := range(closedIssueText) {
+			fmt.Print(txt)
+		}
+	}
+}
+
+func printIssueEvent(event *github.Event) string {
+	payload, _ := event.ParsePayload()
+	issuesEvent := payload.(*github.IssuesEvent)
+	return fmt.Sprintf("ISSUE#%d %s: %s %s\n", 
+		*issuesEvent.Issue.Number, 
+		*issuesEvent.Issue.User.Login,
+		*issuesEvent.Issue.Title,
+		*issuesEvent.Issue.HTMLURL)
+}
+
+func printIssueCommentEventReport(events []*github.Event) {
+	commentMap := make(map[string]int)
+	titleMap := make(map[string]string)
+	for _, event := range(events) {
+		payload, _ := event.ParsePayload()
+		commentEvent := payload.(*github.IssueCommentEvent)
+		url := *commentEvent.Issue.HTMLURL
+		commentMap[url] = commentMap[url] + 1
+		titleMap[url] = *commentEvent.Issue.Title
+	}
+	fmt.Printf("======================\n")
+	fmt.Printf("ISSUE COMMENT ACTIVITY\n")
+	fmt.Printf("======================\n")
+	var commentText = sort.StringSlice{} 
+	for url, val := range(commentMap) {
+		commentText = append(commentText, fmt.Sprintf("Comments:%d %s %s\n", val, titleMap[url], url))
+	}
+	commentText.Sort()
+	for _, txt := range(commentText) {
+			fmt.Print(txt)
+	}
+}
+
+func GenerateEventReport(events []*github.Event) {
+	eventMap := make(map[string][]*github.Event)
+	for _, event := range(events) {
+		eventList, ok := eventMap[*event.Type]
+		if !ok {
+			eventList = []*github.Event{}
+		} 
+		eventList = append(eventList, event)
+		eventMap[*event.Type] = eventList
+	}
+ 	if len(eventMap) == 0 {
+		fmt.Printf("No Events")
+		return
+	}	
+ 	prEvents, _ := eventMap["PullRequestEvent"]	
+	if len(prEvents) != 0 {
+		printPullRequestReport(prEvents)
+	}
+ 	revEvents, _ := eventMap["PullRequestReviewEvent"]	
+ 	revCommentEvents, _ := eventMap["PullRequestReviewCommentEvent"]	
+	revEvents = append(revEvents, revCommentEvents...)
+	if len(revEvents) != 0 {
+		printPullRequestReviewReport(revEvents)
+	}
+ 	issueEvents, _ := eventMap["IssuesEvent"]	
+	if len(issueEvents) != 0 {
+		printIssueEventReport(issueEvents)
+	}
+ 	issueCommentEvents, _ := eventMap["IssueCommentEvent"]	
+	if len(issueCommentEvents) != 0 {
+		printIssueCommentEventReport(issueCommentEvents)
+	}
+	fmt.Printf("============\n")
+	fmt.Printf("EVENT REPORT\n")
+	fmt.Printf("============\n")
+  	for key, val := range(eventMap) {
+		fmt.Printf("%d %s\n", len(val), key)
+	}	
+}

--- a/proxy/repos.go
+++ b/proxy/repos.go
@@ -1,0 +1,39 @@
+/*
+   Copyright awslabs Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+)
+
+func (p *GithubProxy) GetReposForOrg(org string) []string {
+	ctx := context.Background()
+	repos, _, err := p.client.Repositories.ListByOrg(ctx, org, nil)
+	if err != nil {
+		fmt.Printf("%v\n", err)
+		return nil
+	}
+	var repoStrings = []string{}
+	for _, repo := range repos {
+		repoName := *repo.Name
+		if repoName[0:1] != "." {
+			repoStrings = append(repoStrings, repoName)
+		}
+	}
+	return repoStrings
+}


### PR DESCRIPTION
This add the event command which can be used to see events in a repo or all repos for an organization.  It supports three lookbacks modes

HOUR - looks back a number of hours
DATE - gives all events for a date
SINCE - looks back to a timestamp in RFC3339 format.

Tested all scenarios.  Did not test forward looking dates or timestamps