### PR TITLE
Added PR command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,6 +49,7 @@ Simple CLI tool to help monitor and manage projects hosted on GitHub.`
 	}
 	app.Commands = []cli.Command{
 		eventsCommand,
+		prCommand,
 	}
 	app.Action = func(context *cli.Context) error {
 		testingString := context.GlobalString("testing")

--- a/cmd/prs.go
+++ b/cmd/prs.go
@@ -1,0 +1,52 @@
+/*
+   Copyright awslabs Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/sbuckfelder/github-monitoring-tool/proxy"
+	"github.com/urfave/cli"
+)
+
+var prCommand = cli.Command{
+	Name:  "pr",
+	Usage: "List open pull requests events for a github org/repo.  Meant to identify old/stale ps's for triage.",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:     ORG_NAME,
+			Usage:    "github org repo belongs to",
+			Required: true,
+		},
+		cli.StringFlag{
+			Name:     REPO_NAME,
+			Usage:    "github repo to list events for, cannot be used with repoall flag",
+			Required: true,
+		},
+	},
+	Action: func(ctx *cli.Context) error {
+		orgInput := ctx.String(ORG_NAME)
+		repoInput := ctx.String(REPO_NAME)
+
+		ghProxy, err := proxy.NewProxy()
+		if err != nil {
+			panic("Failed to create GitHub client")
+		}
+
+		ghProxy.GetPullRequests(orgInput, repoInput)
+
+		return nil
+	},
+}

--- a/proxy/prs.go
+++ b/proxy/prs.go
@@ -1,0 +1,100 @@
+/*
+   Copyright awslabs Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v48/github"
+)
+
+var PRS_PER_PAGE int = 100
+
+func (p *GithubProxy) GetPullRequests(org ,repo string) {
+	ctx := context.Background()
+	pullRequests, err := p.getAllOpenPullRequests(ctx, org, repo)
+	if err != nil {
+		fmt.Printf("Failed to get pull requests: %v\n", err)
+		return
+	}
+	var output = []string{}
+	for _, PR := range(pullRequests) {
+		comment := p.getLastComment(ctx, org, repo, *PR.Number)
+		commentCsv := ""
+		if comment != nil {
+			commentCsv = fmt.Sprintf("%v,%s",  
+				comment.CreatedAt,
+				*comment.User.Login)
+		}
+		csvLine := fmt.Sprintf("%s,%v,%v,%s,%s\n",
+			*PR.HTMLURL,
+			PR.CreatedAt,
+			PR.UpdatedAt,
+			*PR.User.Login,
+			commentCsv)
+		output = append(output, csvLine) 
+	}
+	for _, line := range(output) {
+		fmt.Println(line)
+	}
+}
+
+func (p *GithubProxy) getAllOpenPullRequests(ctx context.Context, org, repo string) ([]*github.PullRequest, error) {
+	openPRs := []*github.PullRequest{}
+	morePRs := true
+	pageNum := 1
+	for morePRs {
+		prOpts :=  &github.PullRequestListOptions{
+			State: "Open",
+			Sort: "Created",
+			Direction: "asc",
+			ListOptions: github.ListOptions{
+				Page: pageNum,
+				PerPage: PRS_PER_PAGE,
+			},
+		}
+		pullRequests, _, err := p.client.PullRequests.List(ctx, org, repo, prOpts)
+		if err != nil {
+			fmt.Printf("Error Listing Pull Requests: %v\n", err)
+
+		}
+		if len(pullRequests) == 0 {
+			morePRs = false
+		} else {
+			openPRs = append(openPRs, pullRequests...)
+			pageNum++
+		}
+	}
+	return openPRs, nil
+}	
+
+func (p *GithubProxy) getLastComment(ctx context.Context, org, repo string, prNum int) *github.PullRequestComment {
+	commentOpts := &github.PullRequestListCommentsOptions{
+		Sort: "Created",
+		Direction: "desc",
+		ListOptions: github.ListOptions{
+			Page: 1,
+			PerPage: 1,
+		},
+	}
+	comments, _, _ := p.client.PullRequests.ListComments(ctx, org, repo, prNum, commentOpts)
+	if len(comments) == 0 {
+		return nil
+	}
+	return comments[0]
+}


### PR DESCRIPTION
Adds a command that lists all open PRs.  Goal of this command is for it to be used to identify stale PRs that need to be triaged.

Usage `./ghmt pr --org [org] --repo [repo]`

Signed-off-by: Scott Buckfelder <buckscot@amazon.com>